### PR TITLE
docs: add troubleshooting for MCP timeout and Codex permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,50 @@ If you encounter `❌ Permission Error: Operation blocked by sandbox policy`:
 npm install -g @cexll/codex-mcp-server@latest
 ```
 
+#### Common Issues
+
+**Issue 1: MCP Tool Timeout Error**
+
+If you encounter timeout errors when using Codex MCP tools:
+
+```bash
+# Set the MCP tool timeout environment variable (in milliseconds)
+export MCP_TOOL_TIMEOUT=36000000  # 10 hours
+
+# For Windows (PowerShell):
+$env:MCP_TOOL_TIMEOUT=36000000
+
+# For Windows (CMD):
+set MCP_TOOL_TIMEOUT=36000000
+```
+
+Add this to your shell profile (`~/.bashrc`, `~/.zshrc`, or PowerShell profile) to make it permanent.
+
+**Issue 2: Codex Cannot Write Files**
+
+If Codex responds with permission errors like "Operation blocked by sandbox policy" or "rejected by user approval settings", configure your Codex CLI settings:
+
+Create or edit `~/.codex/config.toml`:
+
+```toml
+# Dynamically generated Codex configuration
+model = "gpt-5-codex"
+model_reasoning_effort = "high"
+model_reasoning_summary = "detailed"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+disable_response_storage = true
+network_access = true
+```
+
+**⚠️ Security Warning**: The `danger-full-access` mode grants Codex full file system access. Only use this configuration in trusted environments and for tasks you fully understand.
+
+**Configuration File Locations:**
+- **macOS/Linux**: `~/.codex/config.toml`
+- **Windows**: `%USERPROFILE%\.codex\config.toml`
+
+After updating the configuration, restart your MCP client (Claude Desktop, Claude Code, etc.).
+
 #### Basic Examples
 
 - `use codex to create and run a Python script that processes data`


### PR DESCRIPTION
…sions

- Add MCP_TOOL_TIMEOUT environment variable configuration
- Add Codex CLI config.toml setup for file write permissions
- Include cross-platform instructions (Linux/macOS/Windows)
- Add security warning for danger-full-access mode

Fixes #1

Generated by swe-agent

## Description
<!-- Provide a brief description of the changes in this PR -->

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #(issue number)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style/refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/modification
- [ ] 🔧 Configuration change

## Changes Made
<!-- List the specific changes made in this PR -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->

### Test Configuration
- **Node.js version**: 
- **Codex CLI version**: 
- **Operating System**: 

### Test Steps
1. 
2. 
3. 

### Test Results
<!-- Include any relevant test output or screenshots -->

## Tool-Specific Testing
<!-- If your changes affect specific tools, mark which ones you've tested -->
- [ ] ask-codex
- [ ] brainstorm
- [ ] ping
- [ ] help
- [ ] fetch-chunk
- [ ] timeout-test
- [ ] N/A - Core functionality change

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
- [ ] This PR includes breaking changes

If yes, describe:
- What breaks:
- Migration path:
- Affected users:

## Documentation
<!-- Mark what documentation needs to be updated -->
- [ ] README.md updated
- [ ] API documentation updated
- [ ] VitePress docs updated
- [ ] Code comments added/updated
- [ ] CHANGELOG.md updated
- [ ] No documentation needed

## Checklist
<!-- Ensure all items are completed before submitting the PR -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested my changes locally with `npm run lint`
- [ ] I have tested my changes locally with `npm run build`
- [ ] I have tested the MCP integration with a real client (Claude Desktop/Code)
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, concerns, or discussion points -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Reviewer Notes
<!-- Any specific areas you'd like reviewers to focus on -->

---
**For Maintainers:**
- [ ] Changes reviewed
- [ ] Tests pass
- [ ] Documentation complete
- [ ] Ready to merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a README troubleshooting section for MCP tool timeouts and Codex file write permissions with cross‑platform steps and a security warning.
> 
> - **Documentation (README.md)**
>   - **Common Issues** section added:
>     - *MCP Tool Timeout Error*: Instructions to set `MCP_TOOL_TIMEOUT` (Unix, PowerShell, CMD) and persist via shell profile.
>     - *Codex Cannot Write Files*: Add `~/.codex/config.toml` with `approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, and related settings; includes security warning.
>     - Config file locations for macOS/Linux (`~/.codex/config.toml`) and Windows (`%USERPROFILE%\.codex\config.toml`).
>     - Note to restart MCP client after updating configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23c56b6dcae104da91ecc43cd11ecda6f5b6ee40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->